### PR TITLE
Update `terraform-datadog-monitor` version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -287,7 +287,7 @@ resource "datadog_dashboard" "rds" {
 }
 
 module "monitor_cpu_usage" {
-  source  = "github.com/traveloka/terraform-datadog-monitor?ref=v0.2.0"
+  source  = "github.com/traveloka/terraform-datadog-monitor?ref=v0.3.0"
   enabled = local.monitor_enabled
 
   product_domain = var.product_domain
@@ -311,7 +311,7 @@ module "monitor_cpu_usage" {
 }
 
 module "monitor_free_storage_percentage" {
-  source  = "github.com/traveloka/terraform-datadog-monitor?ref=v0.2.0"
+  source  = "github.com/traveloka/terraform-datadog-monitor?ref=v0.3.0"
   enabled = local.monitor_enabled
 
   product_domain = var.product_domain
@@ -335,7 +335,7 @@ module "monitor_free_storage_percentage" {
 }
 
 module "monitor_db_connection_count" {
-  source  = "github.com/traveloka/terraform-datadog-monitor?ref=v0.2.0"
+  source  = "github.com/traveloka/terraform-datadog-monitor?ref=v0.3.0"
   enabled = local.monitor_enabled
 
   product_domain = var.product_domain
@@ -359,7 +359,7 @@ module "monitor_db_connection_count" {
 }
 
 module "monitor_burst_balance" {
-  source  = "github.com/traveloka/terraform-datadog-monitor?ref=v0.2.0"
+  source  = "github.com/traveloka/terraform-datadog-monitor?ref=v0.3.0"
   enabled = local.monitor_enabled
 
   product_domain = var.product_domain

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 
   required_providers {
-    datadog = "~> 3.0"
+    datadog = {
+      source  = "datadog/datadog"
+      version = "~> 3.0"
+    }
   }
 }


### PR DESCRIPTION
Update `terraform-datadog-version` to version 0.3.0, to be able to support terraform 0.13

**Background**
Tried to create a new RDS dashboard and monitor in flight datadog repo (https://github.com/traveloka/fpr-terraform-datadog), but got error below as the RDS module does not support terraform 0.13 yet, meanwhile all other modules used in that repo already "forced" to use terraform 0.13
<img width="652" alt="Screen Shot 2023-06-13 at 12 22 27" src="https://github.com/traveloka/terraform-datadog-rds/assets/13966178/80ccd943-74dd-40af-a917-b51fa436a3f5">
